### PR TITLE
Add vercel workflow to replace docker,k8 for disaster recovery

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -32,10 +32,6 @@ jobs:
       with:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  publish_to_vercel:
-    runs-on: ubuntu-latest
-    environment: Production
-    steps: 
     - name: Upload to vercel
       id: dr_action
       uses: 'deriv-com/shared-actions/.github/actions/vercel_DR_publish@master'

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -32,6 +32,26 @@ jobs:
       with:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  publish_to_vercel:
+    runs-on: ubuntu-latest
+    environment: Production
+    steps: 
+    - name: Upload to vercel
+      id: dr_action
+      uses: 'deriv-com/shared-actions/.github/actions/vercel_DR_publish@master'
+      with:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
+          ENVIRONMENT: Production
+          VERCEL_SCOPE: deriv
+          ALIAS_DOMAIN_URL: 'sinbad-dr.binary.sx'
+    - name: Send Slack Notification on Vercel Publish failure
+      uses: "deriv-com/shared-actions/.github/actions/send_slack_notification@master"
+      if: steps.dr_action.outcome != 'success'
+      with:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "$RELEASE_TYPE Vercel Deployment for sinbad.software with version ${{ needs.build_and_test.outputs.RELEASE_VERSION }} has Failed"
 
   send_slack_notification:
       name: Send Slack notification

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -26,10 +26,6 @@ jobs:
       with:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  publish_to_vercel:
-    runs-on: ubuntu-latest
-    environment: staging
-    steps: 
     - name: Upload to vercel
       uses: 'deriv-com/shared-actions/.github/actions/vercel_DR_publish@master'
       with:

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -26,3 +26,16 @@ jobs:
       with:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  publish_to_vercel:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps: 
+    - name: Upload to vercel
+      uses: 'deriv-com/shared-actions/.github/actions/vercel_DR_publish@master'
+      with:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
+          ENVIRONMENT: Preview
+          VERCEL_SCOPE: deriv
+          ALIAS_DOMAIN_URL: 'staging-sinbad-dr.binary.sx'

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ yarn-error.log
 
 #CNAME
 static/CNAME
+
+# Vercel
+.vercel

--- a/vercel.dr.json
+++ b/vercel.dr.json
@@ -1,0 +1,5 @@
+{
+  "cleanUrls": true,
+  "outputDirectory": "dist",
+  "buildCommand": "echo ✅  Skipping build to use existing built files"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
Changes:

Implement the disaster recovery workflow for vercel. It implements the new DR solution for the Sinbad repository to ensure continuous availability and reduce the DevOps workload.
- Utilize Vercel for DR deployments.
- Automate the deployment process to Vercel post-release.
- Update the vercel.json configuration.